### PR TITLE
Fix hidden OpenRGB device selection

### DIFF
--- a/OpenRGBBridge.js
+++ b/OpenRGBBridge.js
@@ -155,10 +155,15 @@ export function DiscoveryService() {
 	this.client = undefined;
 	this.refreshId = 0;
 	this.busy = false;
+	// Controller registration is processed from Update(), never directly from a QML
+	// button handler or a TCP callback. Mutating service.controllers while QML is
+	// rendering it is unsafe in current SignalRGB builds and caused refresh crashes.
+	this.controllersDirty = true;
+	this.pendingControllerRemovals = [];
 	// Register a hidden status controller so QML can render a reactive status text by
-	// iterating `service.controllers` (same pattern as the device lists). Without this,
-	// QML never sees status changes because `discovery.getStatus()` returns are cached
-	// by the SignalRGB QML/JS bridge for the lifetime of the page.
+	// iterating `service.controllers`. It also carries a serialized device catalogue,
+	// because suppressed controllers are not reliably exposed in that collection and
+	// therefore cannot be used as the UI's "deleted devices" data source.
 	this.statusController = {
 		id: STATUS_CONTROLLER_ID,
 		deviceId: STATUS_CONTROLLER_ID,
@@ -166,6 +171,7 @@ export function DiscoveryService() {
 		bridgeStatusBus: true,
 		bridgeStatus: this.status,
 		bridgeBusy: false,
+		bridgeDevicesJson: "[]",
 		bridgeStatusRevision: 0
 	};
 	this.lastStatusPublishAt = 0;
@@ -209,6 +215,10 @@ export function DiscoveryService() {
 	};
 
 	this.Update = function () {
+		if (this.controllersDirty) {
+			this.controllersDirty = false;
+			this.syncControllers();
+		}
 		this.publishStatusIfDirty();
 
 		if (this.client) {
@@ -269,18 +279,19 @@ export function DiscoveryService() {
 						return;
 					}
 
+					const knownBeforeRefresh = self.getAllKnownDevices();
 					self.availableDevices = assignStableDeviceIds(devices, host, port);
 					self.availableDeviceSummaries = buildDeviceSummaries(self.availableDevices);
+					self.queueStaleControllers(knownBeforeRefresh, self.availableDevices);
 					saveSetting(LAST_DEVICES_SETTING, JSON.stringify(self.availableDeviceSummaries));
 					const selectedBeforeRefresh = self.selectedDevices.length > 0 ? self.selectedDevices : readSelectedDevices();
 					self.hasStoredSelectedDevices = self.hasStoredSelectedDevices || hasStoredSelectedDevices();
-					removeStaleControllers(selectedBeforeRefresh, self.availableDevices);
 					self.selectedDevices = self.hasStoredSelectedDevices
 						? getSelectedDevicesById(self.availableDevices, selectedBeforeRefresh)
 						: self.availableDeviceSummaries.slice(0);
 					saveSetting(SELECTED_DEVICES_SETTING, JSON.stringify(self.selectedDevices));
 					self.hasStoredSelectedDevices = true;
-					self.syncControllers();
+					self.requestControllerSync();
 					self.needsScan = false;
 					self.finishRefresh(client);
 					self.setStatus("Connected to OpenRGB at " + host + ":" + port + ". Found " + self.availableDevices.length + " device(s).");
@@ -399,7 +410,7 @@ export function DiscoveryService() {
 			return item.deviceId !== deviceId;
 		});
 		this.saveSelection();
-		this.syncControllers();
+		this.requestControllerSync();
 		this.setStatus("Deleted device.");
 		return this.status;
 	};
@@ -411,7 +422,7 @@ export function DiscoveryService() {
 		}
 		this.selectedDevices = [];
 		this.saveSelection();
-		this.syncControllers();
+		this.requestControllerSync();
 		this.setStatus("Deleted all OpenRGB devices.");
 		return this.status;
 	};
@@ -426,7 +437,7 @@ export function DiscoveryService() {
 
 		this.selectedDevices = getSelectedDevicesById(this.availableDevices, this.selectedDevices.concat([deviceData]));
 		this.saveSelection();
-		this.syncControllers();
+		this.requestControllerSync();
 		this.setStatus("Restored " + deviceData.name + ".");
 		return this.status;
 	};
@@ -434,14 +445,14 @@ export function DiscoveryService() {
 	this.restoreAllDevices = function () {
 		this.selectedDevices = this.getAllKnownDevices().slice(0);
 		this.saveSelection();
-		this.syncControllers();
+		this.requestControllerSync();
 		this.setStatus("Restored all OpenRGB devices.");
 		return this.status;
 	};
 
 	this.connectSelectedDevices = function () {
 		this.selectedDevices = readSelectedDevices();
-		this.syncControllers();
+		this.requestControllerSync();
 		return String(this.selectedDevices.length);
 	};
 
@@ -485,6 +496,46 @@ export function DiscoveryService() {
 		}
 	};
 
+	this.queueStaleControllers = function (previousDevices, currentDevices) {
+		const currentIds = getDeviceIds(currentDevices);
+		for (let i = 0; i < (previousDevices || []).length; i++) {
+			const deviceId = previousDevices[i] && previousDevices[i].deviceId;
+			if (!deviceId || currentIds.indexOf(deviceId) >= 0 || this.pendingControllerRemovals.indexOf(deviceId) >= 0) {
+				continue;
+			}
+			this.pendingControllerRemovals.push(deviceId);
+		}
+	};
+
+	// QML receives a stable catalogue through the status carrier instead of deriving
+	// it from service.controllers. In particular, a suppressed controller remains
+	// visible here and can always be restored.
+	this.updateDeviceCatalog = function () {
+		if (!this.statusController) {
+			return;
+		}
+
+		const selectedIds = getDeviceIds(this.selectedDevices);
+		const rows = buildDeviceSummaries(this.getAllKnownDevices());
+		for (let i = 0; i < rows.length; i++) {
+			rows[i].bridgeDeleted = selectedIds.indexOf(rows[i].deviceId) < 0;
+		}
+
+		const json = JSON.stringify(rows);
+		if (this.statusController.bridgeDevicesJson === json) {
+			return;
+		}
+
+		this.statusController.bridgeDevicesJson = json;
+		this.statusController.bridgeStatusRevision++;
+		service.updateController(this.statusController);
+	};
+
+	this.requestControllerSync = function () {
+		this.controllersDirty = true;
+		this.updateDeviceCatalog();
+	};
+
 	this.syncControllers = function () {
 		// Drop the legacy single "OpenRGB Bridge" controller from the merged-subdevice era.
 		closeRenderState(BRIDGE_CONTROLLER_ID);
@@ -498,8 +549,9 @@ export function DiscoveryService() {
 		const knownIds = {};
 
 		// One controller per known device: selected ones are announced as live SignalRGB
-		// devices, the rest stay registered but suppressed so they show up in the QML
-		// "deleted" list (driven by service.controllers) and can be restored.
+		// devices and the rest are suppressed. The QML list is driven by the independent
+		// status-carrier catalogue, so suppression cannot make a device impossible to
+		// restore.
 		for (let i = 0; i < allKnown.length; i++) {
 			const device = allKnown[i];
 			if (!device.deviceId) {
@@ -507,6 +559,20 @@ export function DiscoveryService() {
 			}
 			knownIds[device.deviceId] = true;
 			this.applyController(device, selectedIds.indexOf(device.deviceId) >= 0);
+		}
+
+		const pendingRemovals = this.pendingControllerRemovals;
+		this.pendingControllerRemovals = [];
+		for (let i = 0; i < pendingRemovals.length; i++) {
+			const id = pendingRemovals[i];
+			if (knownIds[id]) {
+				continue;
+			}
+			closeRenderState(id);
+			const controllerToRemove = service.getController(id);
+			if (controllerToRemove !== undefined) {
+				service.removeController(controllerToRemove);
+			}
 		}
 
 		// Drop controllers that are no longer known at all (e.g. stale/legacy ids).
@@ -629,9 +695,8 @@ class OpenRGBController {
 		this.zoneCount = this.zones ? this.zones.length : 0;
 		this.icon = getDeviceIconUrl(this.type);
 		this.image = getBridgeDeviceIconUrl(this.type);
-		// UI flag read reactively by the QML lists (active vs deleted). It is a plain
-		// property on the controller object so it travels through service.controllers,
-		// which is the only reliable QML data channel in SignalRGB.
+		// Tracks whether SignalRGB should announce or suppress this controller. QML gets
+		// its independent active/deleted snapshot from the status-carrier catalogue.
 		this.bridgeDeleted = !!deviceData.bridgeDeleted;
 	}
 
@@ -1749,28 +1814,6 @@ function findDeviceById(devices, deviceId) {
 		}
 	}
 	return undefined;
-}
-
-function removeStaleControllers(previousDevices, currentDevices) {
-	const currentIds = {};
-	for (let i = 0; i < currentDevices.length; i++) {
-		if (currentDevices[i] && currentDevices[i].deviceId) {
-			currentIds[currentDevices[i].deviceId] = true;
-		}
-	}
-
-	for (let i = 0; i < previousDevices.length; i++) {
-		const previousDevice = previousDevices[i] || {};
-		if (!previousDevice.deviceId || currentIds[previousDevice.deviceId]) {
-			continue;
-		}
-
-		closeRenderState(previousDevice.deviceId);
-		const controllerToRemove = service.getController(previousDevice.deviceId);
-		if (controllerToRemove !== undefined) {
-			service.removeController(controllerToRemove);
-		}
-	}
 }
 
 function getZoneLedCount(zone) {

--- a/OpenRGBBridge.qml
+++ b/OpenRGBBridge.qml
@@ -4,10 +4,17 @@ Item {
     readonly property string statusControllerId: "openrgb-bridge-status"
     property string statusText: "Connecting..."
     property bool busy: false
-    // Best-effort counts computed from service.controllers. -1 means "unknown"
-    // (iteration unsupported); the lists themselves never depend on these.
     property int activeCount: 0
     property int deletedCount: 0
+    property string deviceCatalogJson: ""
+
+    ListModel {
+        id: activeDeviceModel
+    }
+
+    ListModel {
+        id: deletedDeviceModel
+    }
 
     function logUi(message) {
         try {
@@ -18,14 +25,56 @@ Item {
         }
     }
 
-    // Device counts, status text and busy flag are all harvested by iterating
-    // SignalRGB's service.controllers collection (the only reliable JS→QML data
-    // channel). The JS side re-publishes the hidden status-bus controller on every
-    // change, so each poll sees a fresh snapshot.
+    function updateDeviceModels(json) {
+        json = String(json || "[]")
+        if (json === deviceCatalogJson) {
+            return
+        }
+
+        var devices = []
+        try {
+            devices = JSON.parse(json)
+        } catch (e) {
+            logUi("Failed to parse OpenRGB Bridge device catalogue: " + String(e))
+            return
+        }
+
+        activeDeviceModel.clear()
+        deletedDeviceModel.clear()
+        for (var i = 0; i < devices.length; i++) {
+            var item = devices[i] || {}
+            var deviceId = String(item.deviceId || "")
+            if (deviceId === "") {
+                continue
+            }
+
+            var row = {
+                "rowDeviceId": deviceId,
+                "rowName": String(item.name || "OpenRGB Device"),
+                "rowVendor": String(item.vendor || ""),
+                "rowOpenrgbIndex": Number(item.openrgbIndex || 0),
+                "rowLedCount": Number(item.ledCount || 0),
+                "rowZoneCount": Number(item.zoneCount || 0),
+                "rowIconSource": String(item.icon || item.image || "")
+            }
+            if (item.bridgeDeleted) {
+                deletedDeviceModel.append(row)
+            } else {
+                activeDeviceModel.append(row)
+            }
+        }
+
+        deviceCatalogJson = json
+        activeCount = activeDeviceModel.count
+        deletedCount = deletedDeviceModel.count
+    }
+
+    // The status carrier is the reliable JS→QML channel. It contains both transient
+    // status and an independent device catalogue, including suppressed devices that
+    // may be absent from service.controllers.
     function refreshTransientState() {
-        var active = 0
-        var deleted = 0
         var foundStatus = ""
+        var foundDeviceCatalog = ""
         var haveStatusBus = false
         var statusBusBusy = false
         try {
@@ -38,23 +87,19 @@ Item {
                 if (String(obj.id || "") === statusControllerId || obj.bridgeStatusBus) {
                     haveStatusBus = true
                     foundStatus = String(obj.bridgeStatus || "")
+                    foundDeviceCatalog = String(obj.bridgeDevicesJson || "[]")
                     statusBusBusy = !!obj.bridgeBusy
-                    continue
-                }
-                if (obj.bridgeDeleted) {
-                    deleted++
-                } else {
-                    active++
                 }
             }
-            activeCount = active
-            deletedCount = deleted
         } catch (e) {
-            activeCount = -1
-            deletedCount = -1
+            busy = readBusy()
+            return
         }
         if (foundStatus !== "") {
             statusText = foundStatus
+        }
+        if (haveStatusBus) {
+            updateDeviceModels(foundDeviceCatalog)
         }
         busy = haveStatusBus ? statusBusBusy : readBusy()
     }
@@ -332,7 +377,7 @@ Item {
 
             ListView {
                 id: activeDeviceList
-                model: service.controllers
+                model: activeDeviceModel
                 width: parent.width
                 height: contentHeight
                 interactive: false
@@ -340,13 +385,8 @@ Item {
                 spacing: 0
 
                 delegate: Item {
-                    property var ctrl: model.modelData.obj
-                    property bool isStatusBus: ctrl ? (String(ctrl.id || "") === statusControllerId || !!ctrl.bridgeStatusBus) : false
-                    property bool isActive: ctrl ? (!ctrl.bridgeDeleted && !isStatusBus) : false
-
                     width: activeDeviceList.width
-                    height: isActive ? 70 : 0
-                    visible: isActive
+                    height: 70
 
                     Rectangle {
                         width: parent.width
@@ -361,7 +401,7 @@ Item {
                             y: 13
                             width: 36
                             height: 36
-                            source: ctrl ? String(ctrl.icon || ctrl.image || "") : ""
+                            source: String(model.rowIconSource || "")
                             fillMode: Image.PreserveAspectFit
                             smooth: true
                         }
@@ -374,7 +414,7 @@ Item {
 
                             Text {
                                 color: "white"
-                                text: ctrl ? String(ctrl.name || "OpenRGB Device") : ""
+                                text: String(model.rowName || "OpenRGB Device")
                                 font.pixelSize: 15
                                 font.family: "Poppins"
                                 font.bold: true
@@ -384,7 +424,7 @@ Item {
 
                             Text {
                                 color: "#cbd5e1"
-                                text: ctrl ? ((ctrl.vendor ? ctrl.vendor + " | " : "") + "Index " + Number(ctrl.openrgbIndex || 0) + " | " + Number(ctrl.ledCount || 0) + " LEDs | " + Number(ctrl.zoneCount || 0) + " zone(s) | " + String(ctrl.deviceId || "")) : ""
+                                text: (model.rowVendor ? model.rowVendor + " | " : "") + "Index " + Number(model.rowOpenrgbIndex || 0) + " | " + Number(model.rowLedCount || 0) + " LEDs | " + Number(model.rowZoneCount || 0) + " zone(s) | " + String(model.rowDeviceId || "")
                                 font.pixelSize: 11
                                 font.family: "Poppins"
                                 width: parent.width
@@ -412,7 +452,7 @@ Item {
                                 text: "Delete"
                                 font.family: "Poppins"
                                 font.bold: true
-                                onClicked: deleteDevice(ctrl ? (ctrl.deviceId || ctrl.id) : "")
+                                onClicked: deleteDevice(model.rowDeviceId)
                             }
                         }
                     }
@@ -474,7 +514,7 @@ Item {
 
             ListView {
                 id: deletedDeviceList
-                model: service.controllers
+                model: deletedDeviceModel
                 width: parent.width
                 height: contentHeight
                 interactive: false
@@ -482,13 +522,8 @@ Item {
                 spacing: 0
 
                 delegate: Item {
-                    property var ctrl: model.modelData.obj
-                    property bool isStatusBus: ctrl ? (String(ctrl.id || "") === statusControllerId || !!ctrl.bridgeStatusBus) : false
-                    property bool isDeleted: ctrl ? (!!ctrl.bridgeDeleted && !isStatusBus) : false
-
                     width: deletedDeviceList.width
-                    height: isDeleted ? 70 : 0
-                    visible: isDeleted
+                    height: 70
 
                     Rectangle {
                         width: parent.width
@@ -503,7 +538,7 @@ Item {
                             y: 13
                             width: 36
                             height: 36
-                            source: ctrl ? String(ctrl.icon || ctrl.image || "") : ""
+                            source: String(model.rowIconSource || "")
                             fillMode: Image.PreserveAspectFit
                             smooth: true
                         }
@@ -516,7 +551,7 @@ Item {
 
                             Text {
                                 color: "#dbeafe"
-                                text: ctrl ? String(ctrl.name || "OpenRGB Device") : ""
+                                text: String(model.rowName || "OpenRGB Device")
                                 font.pixelSize: 15
                                 font.family: "Poppins"
                                 font.bold: true
@@ -526,7 +561,7 @@ Item {
 
                             Text {
                                 color: "#94a3b8"
-                                text: ctrl ? ((ctrl.vendor ? ctrl.vendor + " | " : "") + "Index " + Number(ctrl.openrgbIndex || 0) + " | " + Number(ctrl.ledCount || 0) + " LEDs | " + Number(ctrl.zoneCount || 0) + " zone(s) | " + String(ctrl.deviceId || "")) : ""
+                                text: (model.rowVendor ? model.rowVendor + " | " : "") + "Index " + Number(model.rowOpenrgbIndex || 0) + " | " + Number(model.rowLedCount || 0) + " LEDs | " + Number(model.rowZoneCount || 0) + " zone(s) | " + String(model.rowDeviceId || "")
                                 font.pixelSize: 11
                                 font.family: "Poppins"
                                 width: parent.width
@@ -554,7 +589,7 @@ Item {
                                 text: "Restore"
                                 font.family: "Poppins"
                                 font.bold: true
-                                onClicked: restoreDevice(ctrl ? (ctrl.deviceId || ctrl.id) : "")
+                                onClicked: restoreDevice(model.rowDeviceId)
                             }
                         }
                     }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "description": "SignalRGB addon that controls OpenRGB SDK devices directly over TCP.",
   "scripts": {
-    "validate": "node tools/validate-openrgb-codec.cjs"
+    "validate": "node tools/validate-openrgb-codec.cjs && node tools/validate-openrgb-device-state.cjs"
   }
 }

--- a/tools/validate-openrgb-device-state.cjs
+++ b/tools/validate-openrgb-device-state.cjs
@@ -1,0 +1,189 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const bridgePath = path.join(__dirname, "..", "OpenRGBBridge.js");
+let source = fs.readFileSync(bridgePath, "utf8");
+source = source
+	.replace(/^import tcp from "@SignalRGB\/tcp";\s*/m, "")
+	.replace(/\bexport function\b/g, "function");
+source += "\nglobalThis.__bridgeTest = { DiscoveryService };\n";
+
+const settings = new Map();
+const entries = [];
+const controllers = new Map();
+const announced = [];
+const suppressed = [];
+
+function findEntry(id) {
+	return entries.find((entry) => entry.id === id);
+}
+
+const service = {
+	controllers: entries,
+	getSetting(group, key) {
+		return settings.get(group + ":" + key);
+	},
+	saveSetting(group, key, value) {
+		settings.set(group + ":" + key, value);
+	},
+	getController(id) {
+		return controllers.get(id);
+	},
+	addController(controller) {
+		controllers.set(controller.id, controller);
+		if (!findEntry(controller.id)) {
+			entries.push({ id: controller.id, obj: controller });
+		}
+	},
+	updateController(controller) {
+		controllers.set(controller.id, controller);
+		const entry = findEntry(controller.id);
+		if (entry) {
+			entry.obj = controller;
+		}
+	},
+	removeController(controller) {
+		const id = typeof controller === "string" ? controller : controller.id;
+		const index = entries.findIndex((entry) => entry.id === id);
+		if (index >= 0) {
+			entries.splice(index, 1);
+		}
+		controllers.delete(id);
+	},
+	announceController(controller) {
+		announced.push(controller.id);
+		controllers.set(controller.id, controller);
+		if (!findEntry(controller.id)) {
+			entries.push({ id: controller.id, obj: controller });
+		}
+	},
+	suppressController(controller) {
+		suppressed.push(controller.id);
+		const index = entries.findIndex((entry) => entry.id === controller.id);
+		if (index >= 0) {
+			entries.splice(index, 1);
+		}
+	},
+	log() {}
+};
+
+const context = {
+	console,
+	Date,
+	JSON,
+	Math,
+	Map,
+	Set,
+	Uint8Array,
+	ArrayBuffer,
+	TextDecoder,
+	service,
+	tcp: {},
+	device: { log() {} }
+};
+vm.createContext(context);
+vm.runInContext(source, context, { filename: bridgePath });
+
+const discovery = new context.__bridgeTest.DiscoveryService();
+discovery.needsScan = false;
+
+const gpu = {
+	deviceId: "openrgb-test-gpu",
+	id: "openrgb-test-gpu",
+	name: "MSI RX 6800 Z Trio",
+	vendor: "MSI",
+	openrgbIndex: 0,
+	openrgbHost: "127.0.0.1",
+	openrgbPort: 6742,
+	ledCount: 3,
+	zoneCount: 1,
+	type: 2,
+	zones: [],
+	leds: [],
+	modes: [],
+	colors: []
+};
+
+discovery.availableDevices = [gpu];
+discovery.availableDeviceSummaries = [gpu];
+discovery.selectedDevices = [];
+discovery.requestControllerSync();
+
+assert.equal(
+	service.getController(gpu.deviceId),
+	undefined,
+	"QML-facing actions must not mutate service.controllers synchronously"
+);
+
+let catalogue = JSON.parse(discovery.statusController.bridgeDevicesJson);
+assert.equal(catalogue.length, 1, "a discovered controller must be present in the UI catalogue");
+assert.equal(catalogue[0].deviceId, gpu.deviceId);
+assert.equal(catalogue[0].bridgeDeleted, true, "an unselected controller must be restorable");
+
+discovery.Update();
+assert.ok(service.getController(gpu.deviceId), "the service tick must register the controller");
+assert.deepEqual(suppressed, [gpu.deviceId], "an unselected controller must stay suppressed");
+assert.equal(
+	findEntry(gpu.deviceId),
+	undefined,
+	"the test must reproduce SignalRGB hiding a suppressed controller from QML"
+);
+catalogue = JSON.parse(discovery.statusController.bridgeDevicesJson);
+assert.equal(
+	catalogue[0].bridgeDeleted,
+	true,
+	"the independent catalogue must retain a controller hidden from service.controllers"
+);
+
+discovery.restoreDevice(gpu.deviceId);
+assert.deepEqual(
+	announced,
+	[],
+	"restoring from QML must defer announcement until the service tick"
+);
+catalogue = JSON.parse(discovery.statusController.bridgeDevicesJson);
+assert.equal(catalogue[0].bridgeDeleted, false, "restoring must immediately update the UI catalogue");
+
+discovery.Update();
+assert.deepEqual(announced, [gpu.deviceId], "the next service tick must announce the restored controller");
+assert.ok(findEntry(gpu.deviceId), "announcing must make the controller visible to SignalRGB");
+
+discovery.removeDevice(gpu.deviceId);
+assert.deepEqual(
+	suppressed,
+	[gpu.deviceId],
+	"deleting from QML must defer suppression until the service tick"
+);
+catalogue = JSON.parse(discovery.statusController.bridgeDevicesJson);
+assert.equal(catalogue[0].bridgeDeleted, true, "deleting must leave a restorable catalogue row");
+
+discovery.Update();
+assert.deepEqual(
+	suppressed,
+	[gpu.deviceId, gpu.deviceId],
+	"the next service tick must suppress the deleted controller"
+);
+
+discovery.availableDevices = [];
+discovery.availableDeviceSummaries = [];
+discovery.queueStaleControllers([gpu], []);
+discovery.requestControllerSync();
+assert.ok(
+	service.getController(gpu.deviceId),
+	"removing a stale hidden controller must also be deferred"
+);
+discovery.Update();
+assert.equal(
+	service.getController(gpu.deviceId),
+	undefined,
+	"the service tick must remove stale controllers even when QML cannot see them"
+);
+assert.deepEqual(
+	JSON.parse(discovery.statusController.bridgeDevicesJson),
+	[],
+	"stale controllers must disappear from the independent catalogue"
+);
+
+console.log("OpenRGB device-state validation passed.");


### PR DESCRIPTION
## What changed

- publish an independent serialized device catalogue through the existing status carrier
- render active and deleted device lists from that catalogue instead of `service.controllers`
- defer controller add, announce, suppress, and removal work to `DiscoveryService.Update()`
- add a regression test covering hidden, restored, deleted, and stale controllers

## Root cause

SignalRGB can hide a suppressed controller from the QML-facing `service.controllers` collection. The addon used that same collection to build its deleted-device list, so a detected but unselected controller could produce `Found 1 device(s)` while both UI lists remained empty. Controller collection mutations were also performed directly from QML actions and discovery callbacks, which could race with QML rendering and crash SignalRGB.

## Impact

Detected devices remain visible and restorable even while suppressed, and controller registration changes are applied safely from the service update tick.

## Validation

- `npm run validate`
- OpenRGB codec validation
- device-state regression covering the exact `Found 1 / Devices 0 / Deleted Devices 0` state

Fixes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device synchronization to prevent inconsistent or premature updates.
  * Fixed handling of discovered, removed, suppressed, and restored devices.
  * Improved persistence and display of device selections.

* **UI Improvements**
  * Added reliable active and deleted device lists based on synchronized catalogue data.
  * Device counts and row details now refresh consistently.
  * Restore and delete actions remain available for applicable devices.

* **Tests**
  * Added validation covering device discovery, removal, restoration, suppression, and deferred synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->