### PR TITLE
Fix restored OpenRGB devices showing 0 LEDs

### DIFF
--- a/OpenRGBBridge.js
+++ b/OpenRGBBridge.js
@@ -548,10 +548,9 @@ export function DiscoveryService() {
 		const allKnown = this.getAllKnownDevices();
 		const knownIds = {};
 
-		// One controller per known device: selected ones are announced as live SignalRGB
-		// devices and the rest are suppressed. The QML list is driven by the independent
-		// status-carrier catalogue, so suppression cannot make a device impossible to
-		// restore.
+		// Register only selected devices with SignalRGB. The QML list is driven by the
+		// independent status-carrier catalogue, so inactive devices do not need to leave
+		// behind suppressed controller shells in SignalRGB's internal registry.
 		for (let i = 0; i < allKnown.length; i++) {
 			const device = allKnown[i];
 			if (!device.deviceId) {
@@ -597,38 +596,48 @@ export function DiscoveryService() {
 			return "";
 		}
 
-		deviceData.bridgeDeleted = !active;
+		const deviceId = deviceData.deviceId;
+		let controller = service.getController(deviceId);
 
-		let controller = service.getController(deviceData.deviceId);
-		const isNew = controller === undefined;
-		// Treat a brand new controller as "was deleted" so a new active device announces once.
-		const wasDeleted = isNew ? true : !!controller.bridgeDeleted;
-
-		if (isNew) {
-			controller = new OpenRGBController(deviceData);
-			service.addController(controller);
-		} else if (typeof controller.updateWithValue === "function") {
-			controller.updateWithValue(deviceData);
-		} else {
-			controller.bridgeDeleted = !active;
-			service.updateController(controller);
+		if (!active) {
+			deviceData.bridgeDeleted = true;
+			closeRenderState(deviceId);
+			if (controller !== undefined) {
+				if (typeof service.suppressController === "function") {
+					service.suppressController(controller);
+				}
+				service.removeController(controller);
+			}
+			return deviceId;
 		}
 
-		// Announce / suppress ONLY on a state transition. Re-announcing an already
-		// announced controller spawns duplicate SignalRGB devices (and the extra render
-		// contexts that make streaming laggy); re-suppressing churns the device list.
-		if (active) {
-			if (isNew || wasDeleted) {
-				service.announceController(controller);
-			}
-		} else {
-			closeRenderState(deviceData.deviceId);
-			if ((isNew || !wasDeleted) && typeof service.suppressController === "function") {
+		deviceData.bridgeDeleted = false;
+		const isReusable = controller !== undefined &&
+			typeof controller.updateWithValue === "function" &&
+			!controller.bridgeDeleted;
+
+		if (isReusable) {
+			// Refresh metadata without re-announcing an already active device. Re-announcing
+			// spawns duplicate render contexts and makes streaming increasingly laggy.
+			controller.updateWithValue(deviceData);
+			return deviceId;
+		}
+
+		if (controller !== undefined) {
+			// SignalRGB can retain a lightweight shell after suppressing a controller. Such
+			// a shell has no OpenRGB metadata and is displayed as "Thirdparty Plugin" with
+			// zero LEDs if it is announced again. Always replace it with a complete instance.
+			if (typeof service.suppressController === "function") {
 				service.suppressController(controller);
 			}
+			service.removeController(controller);
 		}
 
-		return deviceData.deviceId;
+		controller = new OpenRGBController(deviceData);
+		service.addController(controller);
+		service.announceController(controller);
+
+		return deviceId;
 	};
 
 	this.setStatus = function (message) {

--- a/tools/validate-openrgb-device-state.cjs
+++ b/tools/validate-openrgb-device-state.cjs
@@ -8,12 +8,13 @@ let source = fs.readFileSync(bridgePath, "utf8");
 source = source
 	.replace(/^import tcp from "@SignalRGB\/tcp";\s*/m, "")
 	.replace(/\bexport function\b/g, "function");
-source += "\nglobalThis.__bridgeTest = { DiscoveryService };\n";
+source += "\nglobalThis.__bridgeTest = { DiscoveryService, Initialize };\n";
 
 const settings = new Map();
 const entries = [];
 const controllers = new Map();
 const announced = [];
+const announcedControllers = [];
 const suppressed = [];
 
 function findEntry(id) {
@@ -54,6 +55,7 @@ const service = {
 	},
 	announceController(controller) {
 		announced.push(controller.id);
+		announcedControllers.push(controller);
 		controllers.set(controller.id, controller);
 		if (!findEntry(controller.id)) {
 			entries.push({ id: controller.id, obj: controller });
@@ -80,8 +82,31 @@ const context = {
 	ArrayBuffer,
 	TextDecoder,
 	service,
-	tcp: {},
-	device: { log() {} }
+	tcp: {
+		createSocket() {
+			return {
+				on() {},
+				connect() {},
+				close() {}
+			};
+		}
+	},
+	device: {
+		log() {},
+		setName(name) {
+			this.name = name;
+		},
+		setImageFromUrl(image) {
+			this.image = image;
+		},
+		setSize(size) {
+			this.size = size;
+		},
+		setControllableLeds(names, positions) {
+			this.ledNames = names;
+			this.ledPositions = positions;
+		}
+	}
 };
 vm.createContext(context);
 vm.runInContext(source, context, { filename: bridgePath });
@@ -123,12 +148,16 @@ assert.equal(catalogue[0].deviceId, gpu.deviceId);
 assert.equal(catalogue[0].bridgeDeleted, true, "an unselected controller must be restorable");
 
 discovery.Update();
-assert.ok(service.getController(gpu.deviceId), "the service tick must register the controller");
-assert.deepEqual(suppressed, [gpu.deviceId], "an unselected controller must stay suppressed");
+assert.equal(
+	service.getController(gpu.deviceId),
+	undefined,
+	"an unselected controller must remain outside SignalRGB's controller registry"
+);
+assert.deepEqual(suppressed, [], "an unselected controller must not create a shell just to suppress it");
 assert.equal(
 	findEntry(gpu.deviceId),
 	undefined,
-	"the test must reproduce SignalRGB hiding a suppressed controller from QML"
+	"the independent catalogue must not require an inactive service.controllers entry"
 );
 catalogue = JSON.parse(discovery.statusController.bridgeDevicesJson);
 assert.equal(
@@ -149,11 +178,13 @@ assert.equal(catalogue[0].bridgeDeleted, false, "restoring must immediately upda
 discovery.Update();
 assert.deepEqual(announced, [gpu.deviceId], "the next service tick must announce the restored controller");
 assert.ok(findEntry(gpu.deviceId), "announcing must make the controller visible to SignalRGB");
+assert.equal(announcedControllers[0].name, gpu.name, "the announced controller must retain its OpenRGB name");
+assert.equal(announcedControllers[0].ledCount, gpu.ledCount, "the announced controller must retain its LED count");
 
 discovery.removeDevice(gpu.deviceId);
 assert.deepEqual(
 	suppressed,
-	[gpu.deviceId],
+	[],
 	"deleting from QML must defer suppression until the service tick"
 );
 catalogue = JSON.parse(discovery.statusController.bridgeDevicesJson);
@@ -162,10 +193,44 @@ assert.equal(catalogue[0].bridgeDeleted, true, "deleting must leave a restorable
 discovery.Update();
 assert.deepEqual(
 	suppressed,
-	[gpu.deviceId, gpu.deviceId],
+	[gpu.deviceId],
 	"the next service tick must suppress the deleted controller"
 );
+assert.equal(
+	service.getController(gpu.deviceId),
+	undefined,
+	"a deleted controller must not leave a stale shell in SignalRGB's registry"
+);
 
+const staleControllerShell = {
+	id: gpu.deviceId,
+	deviceId: gpu.deviceId,
+	bridgeDeleted: true
+};
+controllers.set(gpu.deviceId, staleControllerShell);
+
+discovery.restoreDevice(gpu.deviceId);
+discovery.Update();
+
+assert.deepEqual(
+	announced,
+	[gpu.deviceId, gpu.deviceId],
+	"restoring must announce a controller even when SignalRGB retained a stale shell"
+);
+assert.notEqual(
+	announcedControllers[1],
+	staleControllerShell,
+	"a stale SignalRGB shell must never be announced as the restored device"
+);
+assert.equal(announcedControllers[1].name, gpu.name, "the replacement controller must have the OpenRGB name");
+assert.equal(announcedControllers[1].ledCount, gpu.ledCount, "the replacement controller must have its LEDs");
+
+context.controller = announcedControllers[1];
+context.__bridgeTest.Initialize();
+assert.equal(context.device.name, gpu.name, "device initialization must expose the real OpenRGB name");
+assert.equal(context.device.ledNames.length, gpu.ledCount, "device initialization must expose every OpenRGB LED");
+
+discovery.selectedDevices = [];
 discovery.availableDevices = [];
 discovery.availableDeviceSummaries = [];
 discovery.queueStaleControllers([gpu], []);


### PR DESCRIPTION
## What changed

- keep inactive OpenRGB devices out of SignalRGB's internal controller registry while retaining them in the bridge catalogue
- discard stale or incomplete controller shells before restoring a device
- announce a fresh `OpenRGBController` containing the real device metadata
- extend the device-state regression test through plugin initialization

## Root cause

The bridge registered every discovered device and then suppressed inactive ones. On restore, `service.getController()` could return SignalRGB's lightweight retained controller object rather than the original `OpenRGBController`. Re-announcing that object left SignalRGB without the OpenRGB name and LED metadata, producing a generic `Thirdparty Plugin` device with 0 LEDs and an unusable initialization path.

## User impact

Selecting or restoring an OpenRGB device now announces a complete controller with its real name and LED count. Deleted devices remain restorable through the independent UI catalogue without leaving stale controller objects behind.

## Validation

- `npm run validate`
- `git diff --check`
- regression covers restoring over a stale controller shell and verifies initialization exposes the expected name and 3 LEDs

Fixes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device synchronization so only selected, active devices are registered.
  * Removed inactive or deleted devices cleanly instead of retaining suppressed entries.
  * Restored devices now reappear with complete, up-to-date metadata.
  * Prevented duplicate rendering contexts during device updates.
  * Device initialization now reports the correct device name and LED count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->