### PR TITLE
Fix SignalRGB 2.5.76 TCP discovery and UI sync

### DIFF
--- a/OpenRGBBridge.js
+++ b/OpenRGBBridge.js
@@ -1,7 +1,7 @@
-import { tcp } from "@SignalRGB/tcp";
+import tcp from "@SignalRGB/tcp";
 
 export function Name() { return "OpenRGB Bridge"; }
-export function Version() { return "2.0.1"; }
+export function Version() { return "2.0.2"; }
 export function Type() { return "network"; }
 export function Publisher() { return "Fefe_du_973"; }
 export function Size() { return [1, 1]; }
@@ -21,6 +21,7 @@ const HOST_SETTING = "SDKServerIP";
 const PORT_SETTING = "SDKServerPort";
 const SELECTED_DEVICES_SETTING = "SelectedDevices";
 const LAST_DEVICES_SETTING = "LastDevices";
+const UI_STATE_SETTING = "UiState";
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 6742;
 const CLIENT_PROTOCOL_VERSION = 5;
@@ -151,27 +152,13 @@ export function DiscoveryService() {
 	// button handler or a TCP callback. Mutating service.controllers while QML is
 	// rendering it is unsafe in current SignalRGB builds and caused refresh crashes.
 	this.controllersDirty = true;
+	this.controllerSyncTimer = undefined;
+	this.syncingControllers = false;
 	this.pendingControllerRemovals = [];
-	// Register a hidden status controller so QML can render a reactive status text by
-	// iterating `service.controllers`. It also carries a serialized device catalogue,
-	// because suppressed controllers are not reliably exposed in that collection and
-	// therefore cannot be used as the UI's "deleted devices" data source.
-	this.statusController = {
-		id: STATUS_CONTROLLER_ID,
-		deviceId: STATUS_CONTROLLER_ID,
-		name: "OpenRGB Bridge Status",
-		bridgeStatusBus: true,
-		bridgeStatus: this.status,
-		bridgeBusy: false,
-		bridgeDevicesJson: "[]"
-	};
-	if (service.getController(STATUS_CONTROLLER_ID) === undefined) {
-		service.addController(this.statusController);
-	} else {
-		// Replace the backing value without removing the controller from SignalRGB's
-		// observable network model. QML reads live state through getUiState().
-		service.updateController(this.statusController);
-	}
+	// Keep UI-only state on the discovery service. Registering a synthetic controller
+	// during service construction can stop the discovery thread in SignalRGB 2.5.76.
+	this.deviceCatalogJson = "[]";
+	this.uiStateRevision = 0;
 	// Make one automatic discovery attempt on startup. A failed SDK connection is left
 	// idle until the user explicitly retries, avoiding an endless create/timeout/close
 	// socket loop when OpenRGB is installed but its SDK server is disabled.
@@ -180,13 +167,16 @@ export function DiscoveryService() {
 
 	this.Initialize = function () {
 		this.connectSelectedDevices();
+		// A discovery service with no registered controller is not guaranteed to receive
+		// Update() ticks in SignalRGB 2.5.76. Start the initial SDK discovery here so a
+		// fresh installation can bootstrap its first OpenRGB controllers.
+		const host = normalizeHost(readSetting(HOST_SETTING, DEFAULT_HOST));
+		const port = readNumberSetting(PORT_SETTING, DEFAULT_PORT);
+		this.refresh(host, port);
 	};
 
 	this.Update = function () {
-		if (this.controllersDirty) {
-			this.controllersDirty = false;
-			this.syncControllers();
-		}
+		this.flushControllerSync();
 		if (this.client) {
 			this.client.checkRequestTimeouts();
 			return;
@@ -369,7 +359,7 @@ export function DiscoveryService() {
 			pollToken: String(pollToken === undefined ? "" : pollToken),
 			status: String(this.status || buildLookingForStatus()),
 			busy: !!this.busy,
-			devicesJson: this.statusController ? String(this.statusController.bridgeDevicesJson || "[]") : "[]"
+			devicesJson: String(this.deviceCatalogJson || "[]")
 		});
 	};
 
@@ -485,14 +475,10 @@ export function DiscoveryService() {
 		}
 	};
 
-	// QML receives a stable catalogue through the status carrier instead of deriving
-	// it from service.controllers. In particular, a suppressed controller remains
-	// visible here and can always be restored.
+	// QML receives a stable catalogue directly from the discovery service instead of
+	// deriving it from service.controllers. A suppressed controller remains visible
+	// here and can always be restored.
 	this.updateDeviceCatalog = function () {
-		if (!this.statusController) {
-			return;
-		}
-
 		const selectedIds = getDeviceIds(this.selectedDevices);
 		const rows = buildDeviceSummaries(this.getAllKnownDevices());
 		for (let i = 0; i < rows.length; i++) {
@@ -500,17 +486,49 @@ export function DiscoveryService() {
 		}
 
 		const json = JSON.stringify(rows);
-		if (this.statusController.bridgeDevicesJson === json) {
+		if (this.deviceCatalogJson === json) {
 			return;
 		}
 
-		this.statusController.bridgeDevicesJson = json;
-		service.updateController(this.statusController);
+		this.deviceCatalogJson = json;
+		this.persistUiState();
 	};
 
 	this.requestControllerSync = function () {
 		this.controllersDirty = true;
 		this.updateDeviceCatalog();
+
+		// SignalRGB 2.5.76 does not tick Update() while a discovery service has no
+		// registered controllers. Defer the mutation out of the TCP/QML callback so the
+		// first discovered (or restored) controllers can bootstrap normal Update ticks.
+		if (typeof setTimeout === "function") {
+			if (this.controllerSyncTimer !== undefined && typeof clearTimeout === "function") {
+				clearTimeout(this.controllerSyncTimer);
+			}
+			const self = this;
+			this.controllerSyncTimer = setTimeout(function () {
+				self.controllerSyncTimer = undefined;
+				self.flushControllerSync();
+			}, 50);
+		}
+	};
+
+	this.flushControllerSync = function () {
+		if (this.controllerSyncTimer !== undefined && typeof clearTimeout === "function") {
+			clearTimeout(this.controllerSyncTimer);
+			this.controllerSyncTimer = undefined;
+		}
+		if (!this.controllersDirty || this.syncingControllers) {
+			return;
+		}
+
+		this.controllersDirty = false;
+		this.syncingControllers = true;
+		try {
+			this.syncControllers();
+		} finally {
+			this.syncingControllers = false;
+		}
 	};
 
 	this.syncControllers = function () {
@@ -619,13 +637,19 @@ export function DiscoveryService() {
 
 	this.setStatus = function (message) {
 		this.status = String(message || "");
-		if (this.statusController) {
-			this.statusController.bridgeStatus = this.status;
-			this.statusController.bridgeBusy = !!this.busy;
-			service.updateController(this.statusController);
-		}
+		this.persistUiState();
 		logFromService(this.status);
 		return this.status;
+	};
+
+	this.persistUiState = function () {
+		this.uiStateRevision++;
+		saveSetting(UI_STATE_SETTING, JSON.stringify({
+			revision: this.uiStateRevision,
+			status: String(this.status || buildLookingForStatus()),
+			busy: !!this.busy,
+			devicesJson: String(this.deviceCatalogJson || "[]")
+		}));
 	};
 
 	this.finishRefresh = function (client) {
@@ -636,10 +660,7 @@ export function DiscoveryService() {
 		if (client) {
 			client.close();
 		}
-		if (this.statusController) {
-			this.statusController.bridgeBusy = false;
-			service.updateController(this.statusController);
-		}
+		this.persistUiState();
 	};
 }
 
@@ -745,18 +766,13 @@ class OpenRGBClient {
 
 		try {
 			this.socket = tcp.createSocket();
-			// Current SignalRGB TCP sockets emit "connected". Fall back to the legacy
-			// alias only if an older runtime rejects the current event name.
-			const connectedHandler = this.handleConnected.bind(this);
-			let connectedBound = bindSocketEvent(this.socket, "connected", connectedHandler);
-			if (!connectedBound) {
-				connectedBound = bindSocketEvent(this.socket, "connection", connectedHandler);
-			}
-			if (!connectedBound) {
+			// SignalRGB 2.5.76 exposes "connection" and reports documented aliases such as
+			// "connected" as errors, so bind only the runtime's verified event names.
+			if (!bindSocketEvent(this.socket, "connection", this.handleConnected.bind(this))) {
 				throw new Error("SignalRGB TCP socket exposes no connection event");
 			}
-			bindSocketEvent(this.socket, "disconnected", this.handleDisconnected.bind(this));
-			if (!bindSocketEvent(this.socket, "message", this.handleMessage.bind(this)) ||
+			if (!bindSocketEvent(this.socket, "close", this.handleDisconnected.bind(this)) ||
+				!bindSocketEvent(this.socket, "message", this.handleMessage.bind(this)) ||
 				!bindSocketEvent(this.socket, "error", this.handleError.bind(this))) {
 				throw new Error("SignalRGB TCP socket exposes incomplete event support");
 			}
@@ -817,16 +833,19 @@ class OpenRGBClient {
 			return;
 		}
 
+		// SignalRGB emits "close" synchronously from socket.close(). Detach first so
+		// the close handler cannot recursively close the same socket.
+		const socket = this.socket;
+		this.socket = undefined;
 		try {
-			this.socket.close();
+			socket.close();
 		} catch (error) {
 			try {
-				this.socket.disconnect();
+				socket.disconnect();
 			} catch (_) {
 				// Some SignalRGB socket versions expose close(), others disconnect().
 			}
 		}
-		this.socket = undefined;
 	}
 
 	handleConnected() {
@@ -873,15 +892,18 @@ class OpenRGBClient {
 		// clean slate; without this a half-open socket from a timed-out attempt keeps
 		// resources around and can confuse SignalRGB's TCP module on reconnect.
 		if (this.socket) {
+			// SignalRGB's close event is synchronous. Clear our reference before closing
+			// to make a re-entrant handleDisconnected() call a harmless no-op.
+			const socket = this.socket;
+			this.socket = undefined;
 			try {
-				this.socket.close();
+				socket.close();
 			} catch (_) {
 				try {
-					this.socket.disconnect();
+					socket.disconnect();
 				} catch (_) {
 				}
 			}
-			this.socket = undefined;
 		}
 
 		if (wasConnected) {
@@ -1245,7 +1267,7 @@ function buildSignalRgbLayout(controllerData) {
 			device.createSubdevice(subdeviceId);
 			device.setSubdeviceName(subdeviceId, zone.name || ("Zone " + (zoneIndex + 1)));
 			device.setSubdeviceSize(subdeviceId, map.width, map.height);
-			device.setSubdeviceLeds(subdeviceId, map.names, map.x, map.y);
+			device.setSubdeviceLeds(subdeviceId, map.names, map.positions);
 			state.subdeviceMaps.push({
 				id: subdeviceId,
 				positions: map.positions

--- a/OpenRGBBridge.qml
+++ b/OpenRGBBridge.qml
@@ -74,6 +74,22 @@ Item {
     // only a compatibility fallback and is never removed/re-added by the service.
     function refreshTransientState() {
         pollRevision++
+        // SignalRGB can cache return values from discovery methods across the QML/JS
+        // bridge. The service setting is an atomic, thread-safe state bus updated by
+        // TCP callbacks without mutating SignalRGB's controller model.
+        try {
+            var persistedState = JSON.parse(String(service.getSetting("General", "UiState") || "{}"))
+            if (Number(persistedState.revision || 0) > 0) {
+                if (String(persistedState.status || "") !== "") {
+                    statusText = String(persistedState.status)
+                }
+                updateDeviceModels(String(persistedState.devicesJson || "[]"))
+                busy = !!persistedState.busy
+                return
+            }
+        } catch (e) {
+        }
+
         try {
             var liveState = JSON.parse(String(discovery.getUiState(pollRevision) || "{}"))
             if (String(liveState.pollToken || "") === String(pollRevision)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalrgb-to-openrgb-bridge",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "description": "SignalRGB addon that controls OpenRGB SDK devices directly over TCP.",
   "scripts": {

--- a/tools/validate-openrgb-device-state.cjs
+++ b/tools/validate-openrgb-device-state.cjs
@@ -9,7 +9,7 @@ const rawSource = fs.readFileSync(bridgePath, "utf8");
 let source = rawSource;
 const qmlSource = fs.readFileSync(qmlPath, "utf8");
 source = source
-	.replace(/^import\s+(?:tcp|\{\s*tcp\s*\})\s+from\s+"@SignalRGB\/tcp";\s*/m, "")
+	.replace(/^import\s+tcp\s+from\s+"@SignalRGB\/tcp";\s*/m, "")
 	.replace(/\bexport function\b/g, "function");
 source += "\nglobalThis.__bridgeTest = { DiscoveryService, OpenRGBClient, Initialize };\n";
 
@@ -107,6 +107,9 @@ const context = {
 				},
 				close() {
 					this.closed = true;
+					if (this.handlers.close) {
+						this.handlers.close();
+					}
 				}
 			};
 			sockets.push(socket);
@@ -134,13 +137,23 @@ vm.createContext(context);
 vm.runInContext(source, context, { filename: bridgePath });
 
 assert.match(qmlSource, /discovery\.getUiState\(pollRevision\)/, "QML must poll the live cache-busted state method");
-assert.match(rawSource, /^import \{ tcp \} from "@SignalRGB\/tcp";/m, "the plugin must use SignalRGB's current named TCP import");
-assert.doesNotMatch(source, /republishStatusController/, "the status carrier must never be removed and re-added");
+assert.match(qmlSource, /service\.getSetting\("General", "UiState"\)/, "QML must read the persisted cross-thread UI state");
+assert.match(
+	rawSource,
+	/^import tcp from "@SignalRGB\/tcp";/m,
+	"the plugin must use SignalRGB 2.5.76's default TCP export"
+);
+assert.doesNotMatch(source, /statusController\s*=/, "the discovery service must not register a synthetic status controller");
+assert.match(rawSource, /setSubdeviceLeds\(subdeviceId, map\.names, map\.positions\)/, "subdevice LEDs must use SignalRGB's three-argument API");
 
 const discovery = new context.__bridgeTest.DiscoveryService();
 discovery.needsScan = false;
 const statusControllerId = "openrgb-bridge-status";
-const initialStatusAdds = added.filter((id) => id === statusControllerId).length;
+assert.equal(
+	added.filter((id) => id === statusControllerId).length,
+	0,
+	"service construction must not add a synthetic status controller"
+);
 
 for (let i = 0; i < 5; i++) {
 	discovery.setStatus("Status update " + i);
@@ -148,13 +161,13 @@ for (let i = 0; i < 5; i++) {
 }
 assert.equal(
 	added.filter((id) => id === statusControllerId).length,
-	initialStatusAdds,
-	"status changes must not re-add SignalRGB's network controller"
+	0,
+	"status changes must not add a synthetic status controller"
 );
 assert.equal(
 	removed.filter((id) => id === statusControllerId).length,
 	0,
-	"status changes must never remove SignalRGB's network controller"
+	"status changes must not remove a synthetic status controller"
 );
 
 let uiState = JSON.parse(discovery.getUiState(42));
@@ -192,7 +205,7 @@ assert.equal(
 	"QML-facing actions must not mutate service.controllers synchronously"
 );
 
-let catalogue = JSON.parse(discovery.statusController.bridgeDevicesJson);
+let catalogue = JSON.parse(discovery.deviceCatalogJson);
 assert.equal(catalogue.length, 1, "a discovered controller must be present in the UI catalogue");
 assert.equal(catalogue[0].deviceId, gpu.deviceId);
 assert.equal(catalogue[0].bridgeDeleted, true, "an unselected controller must be restorable");
@@ -209,7 +222,7 @@ assert.equal(
 	undefined,
 	"the independent catalogue must not require an inactive service.controllers entry"
 );
-catalogue = JSON.parse(discovery.statusController.bridgeDevicesJson);
+catalogue = JSON.parse(discovery.deviceCatalogJson);
 assert.equal(
 	catalogue[0].bridgeDeleted,
 	true,
@@ -222,7 +235,7 @@ assert.deepEqual(
 	[],
 	"restoring from QML must defer announcement until the service tick"
 );
-catalogue = JSON.parse(discovery.statusController.bridgeDevicesJson);
+catalogue = JSON.parse(discovery.deviceCatalogJson);
 assert.equal(catalogue[0].bridgeDeleted, false, "restoring must immediately update the UI catalogue");
 
 discovery.Update();
@@ -237,7 +250,7 @@ assert.deepEqual(
 	[],
 	"deleting from QML must defer suppression until the service tick"
 );
-catalogue = JSON.parse(discovery.statusController.bridgeDevicesJson);
+catalogue = JSON.parse(discovery.deviceCatalogJson);
 assert.equal(catalogue[0].bridgeDeleted, true, "deleting must leave a restorable catalogue row");
 
 discovery.Update();
@@ -287,10 +300,16 @@ const protocolClient = new context.__bridgeTest.OpenRGBClient({
 });
 protocolClient.connect();
 const protocolSocket = sockets[sockets.length - 1];
-assert.equal(typeof protocolSocket.handlers.connected, "function", "the client must bind SignalRGB's current connected event");
-protocolSocket.handlers.connected();
-assert.equal(protocolClient.connected, true, "the current connected event must complete the TCP connection");
+assert.equal(typeof protocolSocket.handlers.connection, "function", "the client must bind SignalRGB 2.5.76's connection event");
+assert.equal(typeof protocolSocket.handlers.close, "function", "the client must bind SignalRGB 2.5.76's close event");
+assert.equal(protocolSocket.handlers.connected, undefined, "the client must not bind an event rejected by SignalRGB 2.5.76");
+assert.equal(protocolSocket.handlers.disconnected, undefined, "the client must not bind an event rejected by SignalRGB 2.5.76");
+protocolSocket.handlers.connection();
+assert.equal(protocolClient.connected, true, "the SignalRGB 2.5.76 connection event must complete the TCP connection");
 assert.equal(protocolSocket.sent.length, 1, "connecting must send the OpenRGB protocol-version request");
+protocolSocket.handlers.close();
+assert.equal(protocolClient.connected, false, "the SignalRGB 2.5.76 close event must tear down the connection");
+assert.equal(protocolSocket.closed, true, "the close event must close its socket without recursive overflow");
 protocolClient.close();
 
 const backoffClient = new context.__bridgeTest.OpenRGBClient({
@@ -322,7 +341,7 @@ assert.equal(sockets.length, failedSocketCount, "Update must not create an endle
 assert.equal(
 	removed.filter((id) => id === statusControllerId).length,
 	0,
-	"connection failures must not remove the status controller"
+	"connection failures must not touch a synthetic status controller"
 );
 
 discovery.selectedDevices = [];
@@ -341,7 +360,7 @@ assert.equal(
 	"the service tick must remove stale controllers even when QML cannot see them"
 );
 assert.deepEqual(
-	JSON.parse(discovery.statusController.bridgeDevicesJson),
+	JSON.parse(discovery.deviceCatalogJson),
 	[],
 	"stale controllers must disappear from the independent catalogue"
 );


### PR DESCRIPTION
Fixes #18.

## Root causes

- SignalRGB 2.5.76 exposes the TCP module as a default export, so the documented named import left `tcp` undefined.
- The same runtime emits `connection` / `close`; the documented aliases are rejected.
- `socket.close()` emits `close` synchronously, which made the disconnect handler recursively close the same socket until a stack overflow.
- A discovery service without controllers does not reliably receive `Update()` ticks, so freshly discovered/restored controllers remained queued.
- QML could retain a stale discovery-method result, leaving the UI stuck on “Connecting…” with an empty catalogue.

## Fix

- Use the verified SignalRGB 2.5.76 TCP import and event names.
- Detach sockets before closing them to make synchronous close callbacks re-entrant-safe.
- Start discovery from `Initialize()` and defer controller synchronization outside TCP/QML callbacks.
- Persist one atomic UI-state snapshot through service settings for reliable QML polling.
- Remove the crash-prone synthetic status controller.
- Use SignalRGB’s three-argument subdevice LED API.

## Verification

- `npm run validate`
- Tested locally with SignalRGB 2.5.76 and OpenRGB protocol v5.
- OpenRGB reported and the bridge parsed all 15 controllers.
- The addon state reached `Found 15 device(s)`, `busy=false`, with 15 active devices.
- SignalRGB established 15 persistent OpenRGB render connections.
- No `Maximum call stack size exceeded`, unavailable TCP module, or unknown TCP event errors remained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discovery status and device information now persist across refreshes and initialization.
  * Device catalog updates appear more promptly while controller details synchronize reliably.
* **Bug Fixes**
  * Improved handling of connection and disconnection events to prevent stale or duplicate status information.
  * Fixed device position handling for more accurate LED registration.
* **Chores**
  * Updated the bridge and package version to 2.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->